### PR TITLE
Fix findReserveByDate

### DIFF
--- a/api/markets/model.js
+++ b/api/markets/model.js
@@ -428,8 +428,7 @@ async function findReserveByDate(marketID, date) {
         )
         .whereIn('mb.id', booths)
         .groupBy('mb.id')
-        .orderBy('mb.id')
-        .catch(err => console.error(err))
+        .orderBy('mb.id');
     return result;
 }
 

--- a/api/markets/model.js
+++ b/api/markets/model.js
@@ -428,7 +428,7 @@ async function findReserveByDate(marketID, date) {
         )
         .whereIn('mb.id', booths)
         .groupBy('mb.id')
-        .orderBy('mb.id');
+        .orderBy('mb.id')
     return result;
 }
 

--- a/data/seeds/08_market_reserve.js
+++ b/data/seeds/08_market_reserve.js
@@ -1,6 +1,6 @@
 exports.seed = function(knex) {
-  const date1 = "2019-09-24";
-  const date2 = "2019-09-25";
+  const date1 = "2019-08-24 00:00:00+00";
+  const date2 = "2019-09-25 00:00:00+00";
   const reserve = [
     {
       reserve_date: date1,


### PR DESCRIPTION
# Description

Fixes `findReserveByDate` on `/markets/:id/booths/date/:dt`

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
