### PR TITLE
Fixes GET reservations by date endpoint

### DIFF
--- a/api/markets/index.js
+++ b/api/markets/index.js
@@ -274,7 +274,7 @@ router.get('/:id/booths/date/:dt',
   mw.parentExists({markets: 'id'}),
   mw.validReserveDate({param: 'dt'},{param: 'id'}),
   (req, res) => {
-    Markets.findReserveByDate(req.params.id, req.params.dt)
+    Markets.findReserveByDate(req.params.id, req.params.dt, req.user_id)
     .then(booths => {
       !booths.length
         ? res.status(404).json({ message: 'No booths could be found in our database for that date.' })

--- a/api/markets/model.js
+++ b/api/markets/model.js
@@ -413,15 +413,16 @@ async function removeBooth(id) {
 }
 
 // Market_reserve functions
-async function findReserveByDate(marketID, date) {
+async function findReserveByDate(marketID, date, user_id) {
     const booths = await db('market_booths')
         .where({market_id: marketID})
         .pluck('id');
     const result = await db('market_booths as mb')
-        .select('mb.id', 'mb.number', db.raw('(mb.number - count(mr.id)) as available'), db.raw('array_remove(array_agg(mr.vendor_id ORDER BY mr.vendor_id), NULL) as user_vdrs'))
+        .select('mb.id', 'mb.number', db.raw('(mb.number - count(mr.id)) as available'), db.raw(`ARRAY_REMOVE(ARRAY_AGG(mr.vendor_id ORDER BY mr.vendor_id) FILTER(WHERE mr.user_vdr = ${user_id}), NULL) as user_vdrs`))
         .count({reserved: 'mr.id'})
         .leftJoin(db('market_reserve')
-            .select('id', 'booth_id', 'vendor_id')
+            .select('market_reserve.id', 'market_reserve.booth_id', 'market_reserve.vendor_id', 'v.admin_id as user_vdr')
+            .join('vendors as v', {'v.id': 'market_reserve.vendor_id'})
             .where({'market_reserve.reserve_date': date})
             .as('mr'),
             {'mr.booth_id': 'mb.id'}

--- a/api/markets/model.js
+++ b/api/markets/model.js
@@ -418,6 +418,8 @@ async function findReserveByDate(marketID, date, user_id) {
         .where({market_id: marketID})
         .pluck('id');
     const result = await db('market_booths as mb')
+        // "available" = available booths
+        // "user_vdrs" = array of the user's vendor IDs that have reserved that booth
         .select('mb.id', 'mb.number', db.raw('(mb.number - count(mr.id)) as available'), db.raw(`ARRAY_REMOVE(ARRAY_AGG(mr.vendor_id ORDER BY mr.vendor_id) FILTER(WHERE mr.user_vdr = ${user_id}), NULL) as user_vdrs`))
         .count({reserved: 'mr.id'})
         .leftJoin(db('market_reserve')


### PR DESCRIPTION
# Description

Changes `/markets/:id/booths/date/:dt` endpoint to deliver only the user's vendor IDs in `user_vdrs` (as was originally intended).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
